### PR TITLE
[PICKSW-9624] Passthrough asyncio.CancelledError in tornado coroutines

### DIFF
--- a/tornado/gen.py
+++ b/tornado/gen.py
@@ -221,7 +221,7 @@ def coroutine(
             result = ctx_run(func, *args, **kwargs)
         except (Return, StopIteration) as e:
             result = _value_from_stopiteration(e)
-        except Exception:
+        except (Exception, asyncio.CancelledError):
             future_set_exc_info(future, sys.exc_info())
             try:
                 return future


### PR DESCRIPTION
[PICKSW-9624]: Passthrough asyncio.CancelledError in tornado coroutines

See: https://berkshiregrey.slack.com/archives/C02MFLXPL/p1756324488616899

[PICKSW-9624]: https://berkshiregrey.atlassian.net/browse/PICKSW-9624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ